### PR TITLE
Add git repo check to fix logRepo.Worktree() panic

### DIFF
--- a/cmd/termlog/main.go
+++ b/cmd/termlog/main.go
@@ -109,6 +109,11 @@ have occurred *after* the oldest record in the current logfile`)
 		os.MkdirAll(logDir, 0755)
 	}
 
+	// ensure the log directory is a git repo - panics at logRepo.Worktree() without it
+	if !ham.FileOrDirectoryExists(filepath.Join(logDir, ".git")) {
+		log.Fatalf("%s must be initialized as a git repository", logDir)
+	}
+
 	d, err := db.Open(filepath.Join(expandPath(cfg.Operator.Logdir), "indexed.db"))
 	if err != nil {
 		log.Fatalf("error opening/creating indexed logs: %s", err)


### PR DESCRIPTION
In release 0.2.0, `termlog` panics if the configured `logDir` is not a git repository. 

The setup script could also optionally do this, but having the binary fatal/panic with a meaningful error message seems sufficient to allow others to fix it should they use a non-default `logDir`. 