### PR TITLE
Configurable sig and sig_info for operator

### DIFF
--- a/cmd/termlog/config.go
+++ b/cmd/termlog/config.go
@@ -24,6 +24,8 @@ type Operator struct {
 	County  string
 	State   string
 	Country string
+	Sig     string
+	SigInfo string
 	// GIT related
 	GitPushAfterCommit bool   // If true, push to the log repository after committing the logs
 	GitKey             string // Path to the git key to use (e.g. ~/.ssh/id_rsa)

--- a/cmd/termlog/example-termlog.toml
+++ b/cmd/termlog/example-termlog.toml
@@ -9,6 +9,8 @@
     city = "MyCity"
     state = "MyState"
     country = "United States"
+    sig = "MySig"
+    sigInfo = "MySigInfo"
     logdir = "~/ham-logs/"
 
  [rig]

--- a/cmd/termlog/mainscreen.go
+++ b/cmd/termlog/mainscreen.go
@@ -75,6 +75,11 @@ func newMainScreen(cfg *Config, alog *adif.Log, repo *git.Repository, bookmarks 
 	sb.AddClock("Local")
 	sb.AddText("/")
 	sb.AddClock("UTC")
+	if cfg.Operator.Sig != "" && cfg.Operator.SigInfo != "" {
+		sb.AddText("/")
+		sb.AddText(cfg.Operator.Sig)
+		sb.AddText(cfg.Operator.SigInfo)
+	}
 	c.AddWidget(sb)
 	yPos++
 	remainingHeight--
@@ -386,6 +391,14 @@ func (m *mainScreen) logRoutine() {
 					}
 				}
 			}
+
+			if m.cfg.Operator.Sig != "" {
+				rec.record = append(rec.record, adif.Field{Name: adif.MySIG, Value: m.cfg.Operator.Sig})
+			}
+			if m.cfg.Operator.SigInfo != "" {
+				rec.record = append(rec.record, adif.Field{Name: adif.MySIGInfo, Value: m.cfg.Operator.SigInfo})
+			}
+
 			// upload to LoTW?
 			if !m.cfg.noNet && m.cfg.Operator.LOTWAutoUpload {
 				// possibly adds new fields if successful


### PR DESCRIPTION
- Allow operator to configure their `sig` and `sig_info` fields
- Write the `sig` and `sig_info` fields into the ADIF log
- When `sig` and `sig_info` are set, display the values onto the status bar