### PR TITLE
Use ASCIISet

### DIFF
--- a/dxcc/gen/conv.go
+++ b/dxcc/gen/conv.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/elliotwutingfeng/asciiset"
 )
 
 // reads cty.csv from http://www.country-files.com/
@@ -97,20 +99,21 @@ func splitPrefixes(pfx string) string {
 
 func prefixRegexp(pfx string) string {
 
-	initialChars := map[byte]struct{}{}
+	initialChars, _ := asciiset.MakeASCIISet("")
 	pfx = strings.Replace(pfx, ";", "", -1)
 	for _, p := range strings.Split(pfx, " ") {
 		switch p[0] {
 		case '=':
-			initialChars[p[1]] = struct{}{}
+			initialChars.Add(p[1])
 		default:
-			initialChars[p[0]] = struct{}{}
+			initialChars.Add(p[0])
 		}
 	}
 	var sorted []byte
-	for c := range initialChars {
+	initialChars.Visit(func(c byte) bool {
 		sorted = append(sorted, c)
-	}
+		return false
+	})
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i] < sorted[j]
 	})

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cgrates/ltcache v0.0.0-20181016092649-92fb7fa77cca
 	github.com/dh1tw/goHamlib v0.0.0-20210309231416-3752aec70bb9
 	github.com/dustin/go-humanize v1.0.0
+	github.com/elliotwutingfeng/asciiset v0.0.0-20230905005145-03469a5e6723
 	github.com/go-git/go-git/v5 v5.0.0
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/dh1tw/goHamlib v0.0.0-20210309231416-3752aec70bb9 h1:Nesja9SyFN+AbgzE
 github.com/dh1tw/goHamlib v0.0.0-20210309231416-3752aec70bb9/go.mod h1:jK1ydgaErxhywGam57gVArV1Z20/f/8zUfdSqTmZdTk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230905005145-03469a5e6723 h1:5NV4VYUVfpKnS0rNIvz6KUbpp0DSupqBl9Ebdu6v2II=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230905005145-03469a5e6723/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=


### PR DESCRIPTION
Proposing use of `ASCIISet` instead of `map[byte]struct{}`.

`ASCIISet` is a zero-dependency library for sets of ASCII characters with [28 times faster lookup speed](https://github.com/elliotwutingfeng/asciiset#results) than `map[byte]struct{}`.